### PR TITLE
build: enabled sourceMap

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
         "noImplicitReturns": true,
         "preserveConstEnums": true,
         "experimentalDecorators": true,
-        "sourceMap": false
+        "sourceMap": true
     },
     "include": ["types/**/*.d.ts", "packages/**/*.ts"],
     "exclude": ["packages/**/*.test.ts"]


### PR DESCRIPTION
不开启 sourceMap 会导致 jest 对 ts 单测文件报错定位不准，问题链接：[Jest test of Typescript shows wrong error lines](https://stackoverflow.com/questions/48412159/jest-test-of-typescript-shows-wrong-error-lines)